### PR TITLE
Update eslint configs to warn on unused vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
   plugins: ['react', 'react-hooks', 'prettier'],
   rules: {
     'no-param-reassign': ['error', { props: true, ignorePropertyModificationsFor: ['state'] }],
+    'no-unused-vars': ['warn'],
     'import/prefer-default-export': 0,
     'arrow-parens': ['error', 'as-needed'],
     'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
- Changed the eslint config `no-unused-vars` from `error` to `warn`.