### PR TITLE
Add polyfill for IntersectionObserver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7954,6 +7954,11 @@
         "side-channel": "^1.0.4"
       }
     },
+    "intersection-observer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.0.tgz",
+      "integrity": "sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ=="
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@benestudioco/react-scrollfade": "^1.0.2",
     "classnames": "^2.3.1",
     "inline-style-prefixer": "^6.0.1",
+    "intersection-observer": "^0.12.0",
     "react": "^17.0.2",
     "react-cool-img": "^1.2.12",
     "react-dom": "^17.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom';
 import './stylesheets/index.scss';
 import App from './App';
 
+// IntersectionObserver polyfill
+(async () => {
+  if (!('IntersectionObserver' in window)) await import('intersection-observer');
+})();
+
 ReactDOM.render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
The IntersectionObserver API is used by the [react-cool-img](https://www.npmjs.com/package/react-cool-img) dependency.